### PR TITLE
Fix evaluator edge cases and return values

### DIFF
--- a/index_evaluator.py
+++ b/index_evaluator.py
@@ -59,9 +59,12 @@ def evaluate_all_with_expert_index(authors_data, data_dir, current_year=2013, a=
         result["recency_score"] = r
         results.append(result)
 
+    if not results:
+        return pd.DataFrame(), 0, 0
+
     # 정규화
-    max_q = max(r["quality_score"] for r in results) or 1
-    max_r = max(r["recency_score"] for r in results) or 1
+    max_q = max((r["quality_score"] for r in results), default=0) or 1
+    max_r = max((r["recency_score"] for r in results), default=0) or 1
 
     for r in results:
         q_norm = r["quality_score"] / max_q

--- a/viz_utils.py
+++ b/viz_utils.py
@@ -366,4 +366,5 @@ def plot_author_index_and_activity_time_series(author_id, index_df, data_dir, se
         return plot_df, paper_stats
     else:
         print("⚠️ 논문 데이터가 없어 활동 시각화를 건너뜁니다.")
+        return plot_df, paper_stats
 


### PR DESCRIPTION
## Summary
- guard against empty author results in evaluator
- always return paper stats even when empty

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_68496398e0b08327bae96d43868bfb41