### PR TITLE
Add IPython display import

### DIFF
--- a/index_runner.py
+++ b/index_runner.py
@@ -3,6 +3,7 @@ import pandas as pd
 import numpy as np
 import seaborn as sns
 import matplotlib.pyplot as plt
+from IPython.display import display
 from collections import defaultdict
 from index_evaluator import load_authors_data, evaluate_all_with_expert_index
 from data_utils import load_author_publications, load_author_index_time_series


### PR DESCRIPTION
## Summary
- import `display` from IPython near the top of `index_runner.py`

## Testing
- `python -m py_compile index_runner.py`
- `python index_runner.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68496efc72e4832795dcd498556c8174